### PR TITLE
📦 NEW: Add bot message exclusion

### DIFF
--- a/src/main/java/com/github/princesslana/slothbot/App.java
+++ b/src/main/java/com/github/princesslana/slothbot/App.java
@@ -15,6 +15,7 @@ public class App {
 
     Dispatcher.init(disparse);
 
+    Config.getMessageCounter().load();
     Config.getMessageCounter().start(Config.getSmallD());
 
     Config.getLimiter().load();

--- a/src/main/java/com/github/princesslana/slothbot/Config.java
+++ b/src/main/java/com/github/princesslana/slothbot/Config.java
@@ -17,7 +17,8 @@ public class Config {
 
   private static final ScheduledExecutorService EXECUTOR = Executors.newScheduledThreadPool(32);
 
-  private static final MessageCounter MESSAGE_COUNTER = new MessageCounter(EXECUTOR);
+  private static final MessageCounter MESSAGE_COUNTER =
+      new MessageCounter(EXECUTOR, Path.of(getDataPath(), "counter.json"));
   private static final Limiter LIMITER =
       new Limiter(SMALLD, MESSAGE_COUNTER, EXECUTOR, Path.of(getDataPath(), "limits.json"));
   private static final Self SELF = new Self(SMALLD);

--- a/src/main/java/com/github/princesslana/slothbot/commands/ConfigurationCommand.java
+++ b/src/main/java/com/github/princesslana/slothbot/commands/ConfigurationCommand.java
@@ -1,6 +1,14 @@
 package com.github.princesslana.slothbot.commands;
 
-import com.github.princesslana.slothbot.*;
+import com.github.princesslana.slothbot.Channel;
+import com.github.princesslana.slothbot.Config;
+import com.github.princesslana.slothbot.Discord;
+import com.github.princesslana.slothbot.Embed;
+import com.github.princesslana.slothbot.Limiter;
+import com.github.princesslana.slothbot.MessageCounter;
+import com.github.princesslana.slothbot.Moderator;
+import com.github.princesslana.slothbot.Rate;
+import com.github.princesslana.slothbot.Self;
 import com.github.princesslana.smalld.SmallD;
 import com.google.gson.JsonObject;
 import disparse.discord.smalld.DiscordRequest;
@@ -65,7 +73,7 @@ public class ConfigurationCommand {
 
     embed.addField("Rate Limits", rateLimits.isBlank() ? "None" : rateLimits);
 
-    embed.addField("Count bot messages", counter.getBotCounterConfig(guildId) ? "Yes" : "No");
+    embed.addField("Count bot messages", counter.isCountingBotMessages(guildId) ? "Yes" : "No");
 
     return embed.toGson();
   }

--- a/src/main/java/com/github/princesslana/slothbot/commands/ConfigurationCommand.java
+++ b/src/main/java/com/github/princesslana/slothbot/commands/ConfigurationCommand.java
@@ -1,13 +1,6 @@
 package com.github.princesslana.slothbot.commands;
 
-import com.github.princesslana.slothbot.Channel;
-import com.github.princesslana.slothbot.Config;
-import com.github.princesslana.slothbot.Discord;
-import com.github.princesslana.slothbot.Embed;
-import com.github.princesslana.slothbot.Limiter;
-import com.github.princesslana.slothbot.Moderator;
-import com.github.princesslana.slothbot.Rate;
-import com.github.princesslana.slothbot.Self;
+import com.github.princesslana.slothbot.*;
 import com.github.princesslana.smalld.SmallD;
 import com.google.gson.JsonObject;
 import disparse.discord.smalld.DiscordRequest;
@@ -23,14 +16,21 @@ public class ConfigurationCommand {
   private final Self self;
   private final Moderator moderator;
   private final Limiter limits;
+  private final MessageCounter counter;
 
   public ConfigurationCommand(
-      SmallD smalld, DiscordRequest request, Self self, Moderator moderator, Limiter limits) {
+      SmallD smalld,
+      DiscordRequest request,
+      Self self,
+      Moderator moderator,
+      Limiter limits,
+      MessageCounter counter) {
     this.smalld = smalld;
     this.request = request;
     this.self = self;
     this.moderator = moderator;
     this.limits = limits;
+    this.counter = counter;
   }
 
   @CommandHandler(
@@ -64,6 +64,8 @@ public class ConfigurationCommand {
             .collect(Collectors.joining("\n"));
 
     embed.addField("Rate Limits", rateLimits.isBlank() ? "None" : rateLimits);
+
+    embed.addField("Count bot messages", counter.getBotCounterConfig(guildId) ? "Yes" : "No");
 
     return embed.toGson();
   }

--- a/src/main/java/com/github/princesslana/slothbot/commands/CounterConfigCommand.java
+++ b/src/main/java/com/github/princesslana/slothbot/commands/CounterConfigCommand.java
@@ -24,42 +24,22 @@ public class CounterConfigCommand {
   }
 
   @CommandHandler(
-      commandName = "excludebotmsgs",
-      aliases = {"ebmsg"},
-      description = "Exclude bot messages for slowmode calculation in current server",
+      commandName = "count_bots",
+      description = "Change if bot messages should be counted",
       acceptFrom = IncomingScope.CHANNEL)
   @Usages({
-    @Usage(
-        usage = "",
-        description = "Exclude bot messages for slowmode calculation in current server")
+    @Usage(usage = "true", description = "Count bot messages"),
+    @Usage(usage = "false", description = "Don't count bot messages")
   })
-  public DiscordResponse excludeBotMsgs() {
+  public DiscordResponse countBots() {
     return Try.run(
         () -> {
+          Preconditions.checkArgument(request.getArgs().size() == 1, "The value must be given");
           Preconditions.checkArgument(
-              request.getArgs().isEmpty(), "This command does not take any arguments");
-          counter.setBotCounterConfig(guildId, false);
-          return DiscordResponse.of("Bot messages are excluded from slowmode calculation now.");
-        });
-  }
-
-  @CommandHandler(
-      commandName = "includebotmsgs",
-      aliases = {"ibmsg"},
-      description = "Include bot messages for slowmode calculation in current server",
-      acceptFrom = IncomingScope.CHANNEL)
-  @Usages({
-    @Usage(
-        usage = "",
-        description = "Include bot messages for slowmode calculation in current server")
-  })
-  public DiscordResponse includeBotMsgs() {
-    return Try.run(
-        () -> {
-          Preconditions.checkArgument(
-              request.getArgs().isEmpty(), "This command does not take any arguments");
-          counter.setBotCounterConfig(guildId, true);
-          return DiscordResponse.of("Bot messages are included in slowmode calculation now.");
+              request.getArgs().get(0).matches("^true|false$"), "The value must be true or false");
+          boolean value = Boolean.parseBoolean(request.getArgs().get(0));
+          counter.setBotCounterConfig(guildId, value);
+          return DiscordResponse.of(value ? "Bot messages now are counted" : "Bot messages aren't now counted");
         });
   }
 }

--- a/src/main/java/com/github/princesslana/slothbot/commands/CounterConfigCommand.java
+++ b/src/main/java/com/github/princesslana/slothbot/commands/CounterConfigCommand.java
@@ -1,0 +1,65 @@
+package com.github.princesslana.slothbot.commands;
+
+import com.github.princesslana.slothbot.Discord;
+import com.github.princesslana.slothbot.MessageCounter;
+import com.github.princesslana.smalld.SmallD;
+import com.google.common.base.Preconditions;
+import disparse.discord.smalld.DiscordRequest;
+import disparse.discord.smalld.DiscordResponse;
+import disparse.parser.dispatch.IncomingScope;
+import disparse.parser.reflection.*;
+
+public class CounterConfigCommand {
+
+  private final SmallD smalld;
+  private final DiscordRequest request;
+  private final MessageCounter counter;
+  private final String guildId;
+
+  public CounterConfigCommand(SmallD smalld, DiscordRequest request, MessageCounter counter) {
+    this.smalld = smalld;
+    this.request = request;
+    this.counter = counter;
+    this.guildId = Discord.getGuildId(request);
+  }
+
+  @CommandHandler(
+      commandName = "excludebotmsgs",
+      aliases = {"ebmsg"},
+      description = "Exclude bot messages for slowmode calculation in current server",
+      acceptFrom = IncomingScope.CHANNEL)
+  @Usages({
+    @Usage(
+        usage = "",
+        description = "Exclude bot messages for slowmode calculation in current server")
+  })
+  public DiscordResponse excludeBotMsgs() {
+    return Try.run(
+        () -> {
+          Preconditions.checkArgument(
+              request.getArgs().isEmpty(), "This command does not take any arguments");
+          counter.setBotCounterConfig(guildId, false);
+          return DiscordResponse.of("Bot messages are excluded from slowmode calculation now.");
+        });
+  }
+
+  @CommandHandler(
+      commandName = "includebotmsgs",
+      aliases = {"ibmsg"},
+      description = "Include bot messages for slowmode calculation in current server",
+      acceptFrom = IncomingScope.CHANNEL)
+  @Usages({
+    @Usage(
+        usage = "",
+        description = "Include bot messages for slowmode calculation in current server")
+  })
+  public DiscordResponse includeBotMsgs() {
+    return Try.run(
+        () -> {
+          Preconditions.checkArgument(
+              request.getArgs().isEmpty(), "This command does not take any arguments");
+          counter.setBotCounterConfig(guildId, true);
+          return DiscordResponse.of("Bot messages are included in slowmode calculation now.");
+        });
+  }
+}

--- a/src/main/java/com/github/princesslana/slothbot/commands/CounterConfigCommand.java
+++ b/src/main/java/com/github/princesslana/slothbot/commands/CounterConfigCommand.java
@@ -39,7 +39,8 @@ public class CounterConfigCommand {
               request.getArgs().get(0).matches("^true|false$"), "The value must be true or false");
           boolean value = Boolean.parseBoolean(request.getArgs().get(0));
           counter.setBotCounterConfig(guildId, value);
-          return DiscordResponse.of(value ? "Bot messages now are counted" : "Bot messages aren't now counted");
+          return DiscordResponse.of(
+              value ? "Bot messages now are counted" : "Bot messages aren't now counted");
         });
   }
 }


### PR DESCRIPTION
Added the ability for each server to choose whether to include bot (and webhook) messages in slowmode calculation or not, with such messages not being included in the calculation by default.

Commands: excludebotmsgs/ebmsg, includebotmsgs/ibmsg.

And also added an entry to display the current configuration of this in the configuration command.

I'm bad with naming things so any improvements are appreciated.

Fixes #55.